### PR TITLE
WIP: Move mobile menu down, was underneath logo

### DIFF
--- a/wp-content/plugins/mmenu/css/mmenu.css
+++ b/wp-content/plugins/mmenu/css/mmenu.css
@@ -1,4 +1,4 @@
-.mm-menu,.mm-panels,.mm-panels>.mm-panel{margin:0;left:0;right:0;top:0;bottom:0;z-index:0;box-sizing:border-box}
+.mm-menu,.mm-panels,.mm-panels>.mm-panel{margin:0;left:0;right:0;top:36px;bottom:0;z-index:0;box-sizing:border-box}
 .mm-btn,.mm-menu{box-sizing:border-box}
 .mm-listview a,.mm-listview a:hover,.mm-navbar a,.mm-navbar a:hover{text-decoration:none}
 .mm-hidden{display:none!important}


### PR DESCRIPTION
The 'hamburger' menu toggle is still broken, but the menu now looks like this:

![2016-08-19_407x377](https://cloud.githubusercontent.com/assets/1689020/17820771/b6dbcdd0-664e-11e6-9733-748dd95b5305.png)

Will close #31 
